### PR TITLE
[Feat]: Setting different timers based on the selected answer

### DIFF
--- a/quiz_app/src/components/Question.jsx
+++ b/quiz_app/src/components/Question.jsx
@@ -14,6 +14,15 @@ export default function Question({
     isCorrect: null
   });
 
+  // timer should increaase
+  let TIMER = 10000;
+  if(answer.selectedAnswer) {
+    TIMER= 1000;
+  }
+  if(answer.isCorrect !== null) {
+    TIMER= 2000;
+  }
+
   // handleSelectAnswer
   function handleSelectAnswer(answer) {
     setAnswer({
@@ -44,8 +53,10 @@ export default function Question({
     <div id='question'>
         {/* question timer load */}
         <QuestionTimer 
-          timeout={10000} 
-          onTimeout={onSkipAnswer}
+          key={TIMER}
+          timeout={TIMER} 
+          onTimeout={ answer.selectedAnswer==='' ?  onSkipAnswer: null}
+          mode={answerState}
         />
         <h2>
           { QUESTIONS[index].text }

--- a/quiz_app/src/components/QuestionTImer.jsx
+++ b/quiz_app/src/components/QuestionTImer.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 
-export default function QuestionTimer({ timeout, onTimeout }) {
+export default function QuestionTimer({ 
+  timeout, 
+  onTimeout,
+  mode
+}) {
   const [remainingTime, setRemainingTime] = useState(timeout);
 
   useEffect(() => {
@@ -27,6 +31,10 @@ export default function QuestionTimer({ timeout, onTimeout }) {
   }, []); 
 
   return (
-    <progress id="question-time" max={timeout} value={remainingTime}/>
+    <progress 
+      id="question-time" 
+      max={timeout} 
+      value={remainingTime} 
+      className={mode}/>
   );
 };


### PR DESCRIPTION
- We faces some issue related the timer wiped-out when we selected any answer at the last moment of any progress.
- So for that we simply added conditional approach to timers.
- Which would derived that while any answer has been selected or changed its status then we also update the timers.