### PR TITLE
[Feat]: Aborting requests for query configuration.

### DIFF
--- a/react_events/src/components/Events/FindEventSection.jsx
+++ b/react_events/src/components/Events/FindEventSection.jsx
@@ -14,7 +14,7 @@ export default function FindEventSection() {
   // useQuery for fetch event
   const { data, isPending, isError, error }= useQuery({
     queryKey: ['events', { search: searchTerm}],
-    queryFn: () => fetchEvents( searchTerm )
+    queryFn: ({signal}) => fetchEvents({ signal, searchTerm })
   });
 
   function handleSubmit(event) {

--- a/react_events/src/util/http.js
+++ b/react_events/src/util/http.js
@@ -1,11 +1,11 @@
-export async function fetchEvents(searchTerm) {
+export async function fetchEvents({ signal, searchTerm}) {
   // dynamic search URLs
   let url= 'http://localhost:3000/events';
   if(searchTerm) {
     url += '?search=' + searchTerm
   }
 
-  const response = await fetch(url);
+  const response = await fetch(url, { signal: signal });
 
   if (!response.ok) {
     const error = new Error('An error occurred while fetching the events');


### PR DESCRIPTION
- Cancelling query if we didn't pass anything from the find event section.
- For that we passed the signal and search term which would have checked the signal is aborted or not.